### PR TITLE
Don't run blocker on the Facebook developers site

### DIFF
--- a/chrome/source/facebookBlocker/fbblock.js
+++ b/chrome/source/facebookBlocker/fbblock.js
@@ -6,7 +6,7 @@ document.addEventListener('load', handleBeforeLoadEvent, true);
 function handleBeforeLoadEvent(event) {
 	const element = event.target;
 
-	if(pageURL != 'www.facebook.com'){
+	if(pageURL != 'www.facebook.com' && pageURL != 'developers.facebook.com'){
 		if(element.nodeName == 'IFRAME'){
 			if(element.src.toLowerCase().indexOf('facebook.com/extern/') > 0){
 				element.parentNode.removeChild(element);


### PR DESCRIPTION
Currently this extension breaks the Facebook developers apps dashboard, I'd like it not to :)

(I've tested this as an unpacked extension on 18.0.1025.108 beta )